### PR TITLE
use bulb uuid as identification resource, add sample of configuration

### DIFF
--- a/BulbCharacteristic.js
+++ b/BulbCharacteristic.js
@@ -2,9 +2,9 @@
 let noble = require('noble');
 
 class BulbCharacteristicClass {
-    constructor(bulbAddress, uuid) {
-        this.bulbAddress = bulbAddress;
-        this.uuid = uuid;
+    constructor(bulbUuid, colorUuid) {
+        this.bulbUuid = bulbUuid;
+        this.colorUuid = colorUuid;
         this.connected = false;
         this.poweredOn = false;
         this.connecting = false;
@@ -141,7 +141,9 @@ class BulbCharacteristicClass {
 
         noble.startScanning();
         noble.on('discover', function(peripheral) {
-            if (peripheral.address.toLowerCase() === self.bulbAddress.toLowerCase()) {
+            console.log(peripheral.advertisement.localName);
+            console.log(peripheral.uuid);
+            if (peripheral.uuid === self.bulbUuid) {
                 clearTimeout(connectionTimeout);
                 noble.stopScanning();
                 self.noblePeripheral = peripheral;
@@ -166,7 +168,7 @@ class BulbCharacteristicClass {
                             throw error;
                         }
                         characteristics.forEach(function(characteristic) {
-                            if (characteristic.uuid === self.uuid) {
+                            if (characteristic.uuid === self.colorUuid) {
                                 self.connectCallback(true, self.noblePeripheral, characteristic);
                                 callback();
                             }

--- a/ExtendedBulbHombridgeServicesProvider.js
+++ b/ExtendedBulbHombridgeServicesProvider.js
@@ -20,7 +20,7 @@ class ExtendedBulbHombridgeServicesProviderClass {
     }
 
     getServices() {
-        let playbulb = new PlaybulbClass(this.createColorCharacteristic(this.config['address']));
+        let playbulb = new PlaybulbClass(this.createColorCharacteristic(this.config['uuid']));
         let powerControlPlaybulb = new PowerControlPlaybulbClass(playbulb);
 
         let simpleLightbulbService = new this.homebridgeService.Lightbulb(this.config['name'], 'simple');
@@ -61,8 +61,8 @@ class ExtendedBulbHombridgeServicesProviderClass {
     /**
      * @private
      */
-    createColorCharacteristic(bulbAddress) {
-        return new BulbCharacteristicClass(bulbAddress, colorUUID);
+    createColorCharacteristic(bulbUuid) {
+        return new BulbCharacteristicClass(bulbUuid, colorUUID);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # homebridge-playbulb
+
+Example config:
+
+    "accessories": [{
+        "accessory": "PlayBulb",
+        "name": "Candle",
+        "uuid": "74d4b227c3394c95944948b943aa4033"
+    }],


### PR DESCRIPTION
Migrate to device uuid since playbulb address is always undefined. 

Resolve #2 
